### PR TITLE
fix: timer button states - disable pause/stop when appropriate.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -161,7 +161,7 @@ export default class TimerExtension extends Extension {
    updateMenuButtonVisibilty() {      
       //showStartEntry ? this.menuTimerInputEntry.show() : this.menuTimerInputEntry.hide();
       this.handleButtonStyle(this.menuButtonStop, this.timer.isStopped());
-      this.handleButtonStyle(this.menuButtonPause, this.timer.isPaused());
+      this.handleButtonStyle(this.menuButtonPause, this.timer.isPaused() || this.timer.isStopped());
       this.handleButtonStyle(this.menuButtonResume, this.timer.isRunning());
    }   
 

--- a/extension.js
+++ b/extension.js
@@ -160,8 +160,8 @@ export default class TimerExtension extends Extension {
    // Shows Start/Input Timer or Stop Button in the Menu, depending on the current timer state [running/stopped].
    updateMenuButtonVisibilty() {      
       //showStartEntry ? this.menuTimerInputEntry.show() : this.menuTimerInputEntry.hide();
-      this.handleButtonStyle(this.menuButtonStop, this.timer.isStopped());
-      this.handleButtonStyle(this.menuButtonPause, this.timer.isPaused() || this.timer.isStopped());
+      this.handleButtonStyle(this.menuButtonStop, this.timer.isStopped() || this.timer.isFinished());
+      this.handleButtonStyle(this.menuButtonPause, this.timer.isPaused() || this.timer.isFinished() || this.timer.isStopped());
       this.handleButtonStyle(this.menuButtonResume, this.timer.isRunning());
    }   
 


### PR DESCRIPTION
This pull request fixes:
- Disable the **pause** button when the timer is paused or stopped manually;
- Disable the **stop** and **pause** buttons when the timer is finished.