### PR TITLE
fix: remove invalid Clutter.grab_keyboard call

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -44,7 +44,6 @@ export default class TimerExtension extends Extension {
          if (isOpen) {
             this.menuOpeningDelayID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
                this.menuTimerInputEntry.grab_key_focus();
-               Clutter.grab_keyboard(global.stage, this.menuTimerInputEntry);
                this.menuOpeningDelayID = null;
                return GLib.SOURCE_REMOVE;
             });


### PR DESCRIPTION
Bugfix: remove invalid Clutter.grab_keyboard call

Clutter.grab_keyboard is not a valid function in GJS/Clutter. The input field is already being focused using grab_key_focus(), which is sufficient to capture keyboard input. This fix resolves a TypeError thrown when the menu is opened.

This commit fixes the error message:

```
(gnome-shell:35420): Gjs-CRITICAL **: 01:38:56.271: JS ERROR: TypeError: (intermediate value).grab_keyboard is not a function enable/</this.menuOpeningDelayID<@file:///home/cristiano/.local/share/gnome-shell/extensions/simple-timer@majortomvr.github.com/extension.js:47:24
@resource:///org/gnome/shell/ui/init.js:21:20
```

To test, run the extension with:

```bash
dbus-run-session -- gnome-shell --nested --wayland
```
