### PR TITLE
feat: add '.gitignore' files to ignore temporary and compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gschemas.compiled


### PR DESCRIPTION
**Summary**:  
This PR adds a `.gitignore` file to exclude temporary and compiled files from version control. Specifically, it ignores the `gschemas.compiled` file, which is generated during the build process and should not be tracked.

**Details**:
- Added a `.gitignore` entry for `gschemas.compiled`.
- Helps keep the repository clean and prevents unnecessary files from being committed.

**Why**:  
Tracking generated files like `gschemas.compiled` can clutter the repository and cause merge conflicts. Ignoring them ensures a cleaner and more maintainable codebase.
