### PR TITLE
Center buttons, and make buttons circular to match GNOME visual identity

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -133,7 +133,7 @@ export default class TimerExtension extends Extension {
       this.panelButton.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
       
       // Settings entry
-      const settingsMenuItem = new PopupMenu.PopupImageMenuItem('', 'preferences-system-symbolic');
+      const settingsMenuItem = new PopupMenu.PopupImageMenuItem('', 'preferences-system-symbolic', {style_class: 'control-button'});
       settingsMenuItem.x_align = Clutter.ActorAlign.CENTER;
       settingsMenuItem.connect('activate', () => {
          this.openPreferences();

--- a/extension.js
+++ b/extension.js
@@ -93,11 +93,11 @@ export default class TimerExtension extends Extension {
 
       // PANEL-MENU
       let boxMenuItem = new PopupMenu.PopupBaseMenuItem({ reactive: false, can_focus: false });
-      let boxLayout = new St.BoxLayout({ x_align: Clutter.ActorAlign.START, x_expand: true });      
+      let boxLayout = new St.BoxLayout({ x_align: Clutter.ActorAlign.CENTER, x_expand: true });      
       boxMenuItem.add_child(boxLayout);
 
       // Resume Button
-      this.menuButtonResume = new PopupMenu.PopupImageMenuItem("", "media-playback-start-symbolic");
+      this.menuButtonResume = new PopupMenu.PopupImageMenuItem("", "media-playback-start-symbolic", {style_class: 'control-button'});
       this.menuButtonResume.connect('activate', () => {
          if (this.timer.isFinished() || this.timer.isStopped()) {
             this.timerStart();
@@ -111,7 +111,7 @@ export default class TimerExtension extends Extension {
       this.panelButton.menu.addMenuItem(boxMenuItem);
 
       // Pause Button
-      this.menuButtonPause = new PopupMenu.PopupImageMenuItem("", "media-playback-pause-symbolic");      
+      this.menuButtonPause = new PopupMenu.PopupImageMenuItem("", "media-playback-pause-symbolic", {style_class: 'control-button'});
       this.menuButtonPause.connect('activate', () => {
          this.timer.pause();
          this.updateMenuButtonVisibilty();
@@ -119,7 +119,7 @@ export default class TimerExtension extends Extension {
       boxLayout.add_child(this.menuButtonPause);
 
       // STOP Button
-      this.menuButtonStop = new PopupMenu.PopupImageMenuItem("", "media-playback-stop-symbolic");      
+      this.menuButtonStop = new PopupMenu.PopupImageMenuItem("", "media-playback-stop-symbolic", {style_class: 'control-button'});
       this.menuButtonStop.connect('activate', () => {
          this.timer.reset();
          this.updateTimerLabelStyle();

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -20,3 +20,12 @@
     -natural-hpadding: 2px;
     -minimum-hpadding: 2px;
 }
+
+.control-button {
+    width: 22px;
+    height: 28px;
+    border-radius: 28px;
+    margin: 5px;
+    padding: 5px;
+    padding-left: 11px;
+}


### PR DESCRIPTION
**Description:**  
This update centers the extension's buttons and icons, and changes the button shape to be fully circular.  
The centering of the icons is a subtle visual tweak, but it helps to create a cleaner and more polished appearance.  
These changes aim to better align the extension's design with GNOME’s visual identity, which favors rounded buttons and well-centered elements in its top bar menus and UI.  
Overall, this improves consistency and provides a more native and integrated look for GNOME users.

**Before:**  
![Screenshot from 2025-04-27 16-22-27](https://github.com/user-attachments/assets/a5dbe956-e21c-419e-b049-caa961021641)

**After:**  
![Screenshot from 2025-04-27 16-22-05](https://github.com/user-attachments/assets/9213d189-4ded-43df-9bbe-0a4c1e5e8388)
